### PR TITLE
Fix for u-blox M8 and other minor changes

### DIFF
--- a/trackuino/gps.cpp
+++ b/trackuino/gps.cpp
@@ -238,6 +238,15 @@ void gps_setup() {
   strcpy(gps_aprs_lon, "00000.00E");
 }
 
+void gps_reset_parser() {
+  at_checksum = false;        // CR/LF signals the end of the checksum
+  our_checksum = '$';         // Reset checksums
+  their_checksum = 0;
+  offset = 0;                 // Prepare for the next incoming sentence
+  num_tokens = 0;
+  sentence_type = SENTENCE_UNK;
+}
+
 bool gps_decode(char c)
 {
   int ret = false;
@@ -304,12 +313,8 @@ bool gps_decode(char c)
       if (num_tokens)
         Serial.println();
 #endif
-      at_checksum = false;        // CR/LF signals the end of the checksum
-      our_checksum = '$';         // Reset checksums
-      their_checksum = 0;
-      offset = 0;                 // Prepare for the next incoming sentence
-      num_tokens = 0;
-      sentence_type = SENTENCE_UNK;
+
+      gps_reset_parser();
       break;
     
     case '*':

--- a/trackuino/gps.cpp
+++ b/trackuino/gps.cpp
@@ -307,8 +307,17 @@ bool gps_decode(char c)
           gps_speed = new_speed;
           gps_altitude = new_altitude;
           ret = true;
+#ifdef DEBUG_GPS
+          Serial.print(" ACCEPT");
+#endif
         }
+      } else {
+#ifdef DEBUG_GPS
+        Serial.print(" (BAD!) ");
+        Serial.print(millis());
+#endif
       }
+
 #ifdef DEBUG_GPS
       if (num_tokens)
         Serial.println();

--- a/trackuino/gps.cpp
+++ b/trackuino/gps.cpp
@@ -244,6 +244,7 @@ bool gps_decode(char c)
 
   switch(c) {
     case '\r':
+      break;
     case '\n':
       // End of sentence
 

--- a/trackuino/gps.cpp
+++ b/trackuino/gps.cpp
@@ -135,9 +135,9 @@ unsigned char from_hex(char a)
 
 void parse_sentence_type(const char *token)
 {
-  if (strcmp(token, "$GPGGA") == 0) {
+  if (strcmp(token+3, "GGA") == 0) {
     sentence_type = SENTENCE_GGA;
-  } else if (strcmp(token, "$GPRMC") == 0) {
+  } else if (strcmp(token+3, "RMC") == 0) {
     sentence_type = SENTENCE_RMC;
   } else {
     sentence_type = SENTENCE_UNK;

--- a/trackuino/gps.h
+++ b/trackuino/gps.h
@@ -33,5 +33,6 @@ extern float gps_altitude;
 
 void gps_setup();
 bool gps_decode(char c);
+void gps_reset_parser();
 
 #endif

--- a/trackuino/trackuino.ino
+++ b/trackuino/trackuino.ino
@@ -135,6 +135,12 @@ void loop()
     // Show modem ISR stats from the previous transmission
     afsk_debug();
 #endif
+
+  } else {
+    // Discard GPS data received during sleep window
+    while (Serial.available()) {
+      Serial.read();
+    }
   }
 
   power_save(); // Incoming GPS data or interrupts will wake us up

--- a/trackuino/trackuino.ino
+++ b/trackuino/trackuino.ino
@@ -107,6 +107,10 @@ void get_pos()
   int valid_pos = 0;
   uint32_t timeout = millis();
 
+#ifdef DEBUG_GPS
+  Serial.println("\nget_pos()");
+#endif
+
   gps_reset_parser();
 
   do {

--- a/trackuino/trackuino.ino
+++ b/trackuino/trackuino.ino
@@ -106,6 +106,9 @@ void get_pos()
   // Get a valid position from the GPS
   int valid_pos = 0;
   uint32_t timeout = millis();
+
+  gps_reset_parser();
+
   do {
     if (Serial.available())
       valid_pos = gps_decode(Serial.read());


### PR DESCRIPTION
I use the Trackuino firmware on my own custom board with an Arduino Pro Mini and u-blox M8N GPS.  This pull request fixes a problem I encountered parsing the NMEA data from the M8.  It also addresses a few small issues I observed while the code was instrumented for debugging, which I would classify as minor cleanups.  Please see the individual commits for more detail.
